### PR TITLE
Use main tornado ioloop for all websocket operations

### DIFF
--- a/dxlconsole/console.py
+++ b/dxlconsole/console.py
@@ -270,6 +270,7 @@ class WebConsole(Application):
             if module.enabled:
                 handlers.extend(module.handlers)
 
+        self._io_loop = IOLoop.instance()
         super(WebConsole, self).__init__(handlers, **settings)
 
     @property
@@ -290,6 +291,15 @@ class WebConsole(Application):
         """
         return self._modules
 
+    @property
+    def io_loop(self):
+        """
+        Returns the Tornado IOLoop that the web console uses
+
+        :return: The Tornado IOLoop instance
+        """
+        return self._io_loop
+
     def start(self):
         """
         Starts the web console
@@ -300,4 +310,4 @@ class WebConsole(Application):
             "keyfile": client_config.private_key,
         })
         http_server.listen(self._bootstrap_app.port)
-        IOLoop.instance().start()
+        self._io_loop.start()

--- a/dxlconsole/modules/monitor/module.py
+++ b/dxlconsole/modules/monitor/module.py
@@ -292,6 +292,15 @@ class MonitorModule(Module):
             with self._client_dict_lock:
                 self._client_dict[client_id] = (self._client_dict[client_id][0], datetime.datetime.now())
 
+    @property
+    def io_loop(self):
+        """
+        Returns the Tornado IOLoop that the web console uses
+
+        :return: The Tornado IOLoop instance
+        """
+        return self.app.io_loop
+
     def add_web_socket(self, client_id, web_socket):
         """
         Stores a web socket associated with the given client id
@@ -320,7 +329,9 @@ class MonitorModule(Module):
         with self._web_socket_dict_lock:
             for key in self._web_socket_dict:
                 try:
-                    IOLoop.current().add_callback(self._web_socket_dict[key].write_message, u"serviceUpdates")
+                    self.io_loop.add_callback(
+                        self._web_socket_dict[key].write_message,
+                        u"serviceUpdates")
                 except:
                     pass
 

--- a/dxlconsole/modules/monitor/websocket_handler.py
+++ b/dxlconsole/modules/monitor/websocket_handler.py
@@ -1,7 +1,6 @@
 import logging
 import tornado
 from dxlclient import EventCallback, ResponseCallback
-from tornado.ioloop import IOLoop
 from tornado.websocket import WebSocketHandler
 
 logger = logging.getLogger(__name__)
@@ -26,7 +25,8 @@ class _WebSocketEventCallback(EventCallback):
         """
         logger.debug("Received event on topic: " + event.destination_topic)
         self._module.queue_message(event, self._socket._client_id)
-        IOLoop.current().add_callback(self._socket.write_message, u"messagesPending")
+        self._module.io_loop.add_callback(self._socket.write_message,
+                                          u"messagesPending")
 
 
 class _WebSocketResponseCallback(ResponseCallback):
@@ -46,9 +46,11 @@ class _WebSocketResponseCallback(ResponseCallback):
 
         :param response: the incoming response
         """
-        logger.debug("Received response to message: " + response.request_message_id)
+        logger.debug(
+            "Received response to message: " + response.request_message_id)
         self._module.queue_message(response, self._socket._client_id)
-        IOLoop.current().add_callback(self._socket.write_message, u"messagesPending")
+        self._module.io_loop.add_callback(self._socket.write_message,
+                                          u"messagesPending")
 
 
 class ConsoleWebSocketHandler(WebSocketHandler):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ dist = setup(
 
     # Requirements
     install_requires=[
-        "tornado<5",
+        "tornado",
         "dxlbootstrap>=0.1.3",
         "dxlclient",
         "beautifulSoup4"


### PR DESCRIPTION
Previously, calls made to use the Tornado IOLoop to coordinate websocket
writes were done from different threads by calling current() in the
Tornado library. In Tornado 5+, current() no longer returns the global
IOLoop object which was started from the main thread, leading to the
callbacks being sent through non-main threads (including from DXL event
and request callback threads) to fail.

In this commit, the initial IOLoop object created on the main thread
is passed around to the different callback users. This allows both
Tornado 4.x and Tornado 5.x callback usages to perform websocket writes
successfully. In conjunction with the IOLoop change, the tornado
dependency is unpinned from <5 in order to allow users to use the
newer Tornado version.