### PR TITLE
Remove redundant pip deps from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ VOLUME ["/opt/dxlconsole-config"]
 
 EXPOSE 8443
 
-# Install required packages
-RUN pip install "tornado<5" "dxlbootstrap>=0.1.3" "dxlclient"
-
 # Copy application files
 COPY . /tmp/build
 WORKDIR /tmp/build
@@ -15,11 +12,8 @@ WORKDIR /tmp/build
 # Clean application
 RUN python ./clean.py
 
-# Build application
-RUN python ./setup.py bdist_wheel
-
-# Install application
-RUN pip install dist/*.whl
+# Install application package and its dependencies
+RUN pip install .
 
 # Cleanup build
 RUN rm -rf /tmp/build


### PR DESCRIPTION
This commit removes lines from the Dockerfile which install service
dependencies and build a separate wheel file. The Dockerfile instead
just pip installs the current project, which installs the service and
its dependencies defined in the setup.py file.